### PR TITLE
Implement `updateViewState` Mutation for Interactive ViewState Rearrangement

### DIFF
--- a/backend/src/__generated__/resolvers-types.ts
+++ b/backend/src/__generated__/resolvers-types.ts
@@ -275,6 +275,7 @@ export type Mutation = {
   updateIssue?: Maybe<Issue>;
   updateIssueComment?: Maybe<IssueComment>;
   updateMe?: Maybe<User>;
+  updateViewState?: Maybe<Array<Maybe<ViewState>>>;
   uploadAsset?: Maybe<Asset>;
 };
 
@@ -372,6 +373,10 @@ export type MutationUpdateIssueCommentArgs = {
 
 export type MutationUpdateMeArgs = {
   input: UpdateMeInput;
+};
+
+export type MutationUpdateViewStateArgs = {
+  input: UpdateViewStateInput;
 };
 
 export type MutationUploadAssetArgs = {
@@ -535,6 +540,11 @@ export type UpdateMeInput = {
   firstName?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
   settings?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateViewStateInput = {
+  id: Scalars['ID']['input'];
+  positionIndex?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type UploadAssetInput = {
@@ -721,6 +731,7 @@ export type ResolversTypes = ResolversObject<{
   UpdateIssueCommentInput: ResolverTypeWrapper<Partial<UpdateIssueCommentInput>>;
   UpdateIssueInput: ResolverTypeWrapper<Partial<UpdateIssueInput>>;
   UpdateMeInput: ResolverTypeWrapper<Partial<UpdateMeInput>>;
+  UpdateViewStateInput: ResolverTypeWrapper<Partial<UpdateViewStateInput>>;
   Upload: ResolverTypeWrapper<Partial<Scalars['Upload']['output']>>;
   UploadAssetInput: ResolverTypeWrapper<Partial<UploadAssetInput>>;
   User: ResolverTypeWrapper<Partial<User>>;
@@ -783,6 +794,7 @@ export type ResolversParentTypes = ResolversObject<{
   UpdateIssueCommentInput: Partial<UpdateIssueCommentInput>;
   UpdateIssueInput: Partial<UpdateIssueInput>;
   UpdateMeInput: Partial<UpdateMeInput>;
+  UpdateViewStateInput: Partial<UpdateViewStateInput>;
   Upload: Partial<Scalars['Upload']['output']>;
   UploadAssetInput: Partial<UploadAssetInput>;
   User: Partial<User>;
@@ -1053,6 +1065,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationUpdateMeArgs, 'input'>
+  >;
+  updateViewState?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['ViewState']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateViewStateArgs, 'input'>
   >;
   uploadAsset?: Resolver<
     Maybe<ResolversTypes['Asset']>,

--- a/backend/src/type-defs.ts
+++ b/backend/src/type-defs.ts
@@ -394,6 +394,11 @@ const typeDefs = gql`
     title: String
   }
 
+  input UpdateViewStateInput {
+    id: ID!
+    positionIndex: Int
+  }
+
   # Mutations
   type Mutation {
     createProject(input: CreateProjectInput): Project
@@ -434,6 +439,7 @@ const typeDefs = gql`
     createViewState(input: CreateViewStateInput!): [ViewState]
     addItemToViewState(input: AddItemToViewStateItemInput!): [ViewState]
     removeItemFromViewState(input: RemoveItemFromViewStateItemInput!): [ViewState]
+    updateViewState(input: UpdateViewStateInput!): [ViewState]
   }
 
   # Queries

--- a/frontend/components/KanbanBoard/index.tsx
+++ b/frontend/components/KanbanBoard/index.tsx
@@ -40,6 +40,7 @@ import {
   GET_ME,
   GET_PROJECT_INFO,
   UPDATE_ISSUE_MUTATION,
+  UPDATE_VIEW_STATE_MUTATION,
 } from '@/gql/gql-queries-mutations';
 import useWsAuthenticatedSocket from '@/hooks/useWsAuthenticatedSocket';
 import { getDomainName } from '@/services/utils';
@@ -104,6 +105,7 @@ export default function KanbanBoard({
   const [updateIssue] = useMutation(UPDATE_ISSUE_MUTATION);
   const [addIssueStatus] = useMutation(CREATE_ISSUE_STATUS_MUTATION);
   const [addItemToViewState] = useMutation(ADD_ITEM_TO_VIEW_STATE);
+  const [updateViewState] = useMutation(UPDATE_VIEW_STATE_MUTATION);
 
   const getMe = useQuery(GET_ME);
   const getProjectInfo = useQuery(GET_PROJECT_INFO, {
@@ -485,7 +487,21 @@ export default function KanbanBoard({
           containers: newItems,
         };
       });
-      // console.log({ newItems, containers });
+
+      updateViewState({
+        onCompleted: (data) => {
+          setPageState((prevState) => ({
+            ...prevState,
+            boardVersion: prevState.boardVersion + 1,
+          }));
+        },
+        variables: {
+          input: {
+            id: containers[activeContainerIndex].id,
+            positionIndex: overContainerIndex,
+          },
+        },
+      });
     }
 
     // Handling item moving to another container

--- a/frontend/gql/__generated__/graphql.ts
+++ b/frontend/gql/__generated__/graphql.ts
@@ -274,6 +274,7 @@ export type Mutation = {
   updateIssue?: Maybe<Issue>;
   updateIssueComment?: Maybe<IssueComment>;
   updateMe?: Maybe<User>;
+  updateViewState?: Maybe<Array<Maybe<ViewState>>>;
   uploadAsset?: Maybe<Asset>;
 };
 
@@ -395,6 +396,11 @@ export type MutationUpdateIssueCommentArgs = {
 
 export type MutationUpdateMeArgs = {
   input: UpdateMeInput;
+};
+
+
+export type MutationUpdateViewStateArgs = {
+  input: UpdateViewStateInput;
 };
 
 
@@ -567,6 +573,11 @@ export type UpdateMeInput = {
   firstName?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
   settings?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateViewStateInput = {
+  id: Scalars['ID']['input'];
+  positionIndex?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type UploadAssetInput = {

--- a/frontend/gql/gql-queries-mutations.ts
+++ b/frontend/gql/gql-queries-mutations.ts
@@ -483,3 +483,11 @@ export const ADD_ITEM_TO_VIEW_STATE = gql(/* GraphQL */ `
     }
   }
 `);
+
+export const UPDATE_VIEW_STATE_MUTATION = gql(/* GraphQL */ `
+  mutation UpdateViewState($input: UpdateViewStateInput!) {
+    updateViewState(input: $input) {
+      ...ViewStateFields
+    }
+  }
+`);


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new GraphQL mutation `updateViewState` to the backend schema, allowing for the updating of view state positions.
- Implemented the mutation resolver `updateViewState` in the backend to handle view state updates within a database transaction.
- Defined the `UpdateViewStateInput` GraphQL input type for the `updateViewState` mutation.
- Integrated the `updateViewState` mutation into the frontend `KanbanBoard` component to enable interactive rearrangement of the view.
- Updated the generated GraphQL types to reflect the new `updateViewState` mutation.
- Created a new GraphQL mutation string `UPDATE_VIEW_STATE_MUTATION` in the frontend for use with the Apollo client.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resolvers-types.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        backend/src/__generated__/resolvers-types.ts<br><br>

**Add `updateViewState` mutation type and input definition to <br>the GraphQL schema.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-2de791eae31433fc6745786e3771631ff66404381db5e465d65d4bb686fd44ad"> +18/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        backend/src/resolvers/board/index.ts<br><br>

**Implement `updateViewState` mutation logic to handle view <br>state updates in the database.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-1cff4447db308b65985b8365df9a523a656fcf46463d980e4b17bf72969fa373"> +55/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>type-defs.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        backend/src/type-defs.ts<br><br>

**Define `UpdateViewStateInput` GraphQL input type and add <br>`updateViewState` mutation to the schema.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-e72320e211b39cf6782fd25ef10f54204a1bbb2305f27480660db2dfc1072ec5"> +6/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        frontend/components/KanbanBoard/index.tsx<br><br>

**Integrate `updateViewState` mutation into the KanbanBoard <br>component to update the view state on the frontend.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-72b924d91e4e59a598de68713186daed82a504a85a54d1e02ad26128ce9db12c"> +17/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graphql.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        frontend/gql/__generated__/graphql.ts<br><br>

**Update generated GraphQL types to include `updateViewState` <br>mutation.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-c4951772df604fcac415ac7fb71442bb793c5ea43f55e8395a620172a88166f8"> +11/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gql-queries-mutations.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        frontend/gql/gql-queries-mutations.ts<br><br>

**Add `UPDATE_VIEW_STATE_MUTATION` GraphQL mutation for <br>updating view state.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/openpro-io/openpro/pull/31/files#diff-74cc0e508e952171ef14d6d52e268be22319e366a64a6b8454f907cf2561df64"> +8/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
